### PR TITLE
check for string length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 2.0.4 (5. January 2019)
+
++ [#28](https://github.com/luyadev/luya-module-crawler/pull/28) Ensure levenshtein input string does not exceed 255 chars.
+
 ## 2.0.3 (5. December 2019)
 
 + [#26](https://github.com/luyadev/luya-module-crawler/pull/26) Improve handling with lot of data, add more verbosity, add unit tests.

--- a/src/models/Index.php
+++ b/src/models/Index.php
@@ -369,6 +369,11 @@ class Index extends NgRestModel
      */
     public static function didYouMean($query, $languageInfo, $ignoreDistance = 6)
     {
+        // levenshtein can only handle a max length of 255 chars
+        if (strlen($query) > 255) {
+            return false;
+        }
+
         $batch = Searchdata::find()
             ->select(['query', 'id' => 'min(id)'])
             ->where([

--- a/tests/widgets/DidYouMeanWidgetTest.php
+++ b/tests/widgets/DidYouMeanWidgetTest.php
@@ -9,6 +9,17 @@ use luya\crawler\models\Index;
 
 class DidYouMeanWidgetTest extends CrawlerTestCase
 {
+    public function testLength()
+    {
+        $string256 = 'XVH7jCOxgZg229KRxNKxtI7xIOjOKBjQH9Vlu8e3GvAThVFf4TMapqlHHV5Qn32uikOMblKdIcru2mYWHPSyCShdDarRpkR20Bo2ubE2uUI7f3IFt2JPjCHzt5PzkUBuyWTdlmoE148zS3VYbfqi2dE7otM4oBebaXDksFJYyIi0hghr1AQYkAQYpfiKbhRhBaycluL9vH8LyegbVq38Bpnkgry9sJxh9loxQcm7rgw7eoZeHNbR0LFf0O16xI8t';
+
+        $this->assertFalse(Index::didYouMean($string256, 'de'));
+
+        $string255 = 'VH7jCOxgZg229KRxNKxtI7xIOjOKBjQH9Vlu8e3GvAThVFf4TMapqlHHV5Qn32uikOMblKdIcru2mYWHPSyCShdDarRpkR20Bo2ubE2uUI7f3IFt2JPjCHzt5PzkUBuyWTdlmoE148zS3VYbfqi2dE7otM4oBebaXDksFJYyIi0hghr1AQYkAQYpfiKbhRhBaycluL9vH8LyegbVq38Bpnkgry9sJxh9loxQcm7rgw7eoZeHNbR0LFf0O16xI8t';
+
+        $this->assertFalse(Index::didYouMean($string255, 'de'));
+    }
+
     public function testRunNoIndex()
     {
         $provider = new ArrayDataProvider([


### PR DESCRIPTION
check for string length in order to prevent:

yii\base\ErrorException: levenshtein(): Argument string(s) too long
